### PR TITLE
Add remote sync API and export script

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import logging
 
 from app.database import init_db
-from app.routers import posts_router, contributors_router, analytics_router, scraper_router
+from app.routers import posts_router, contributors_router, analytics_router, scraper_router, sync_router
 from app.services.scheduler import scheduler_service
 
 # Configure logging
@@ -61,6 +61,7 @@ app.include_router(posts_router)
 app.include_router(contributors_router)
 app.include_router(analytics_router)
 app.include_router(scraper_router)
+app.include_router(sync_router)
 
 
 @app.get("/")

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -2,5 +2,6 @@ from app.routers.posts import router as posts_router
 from app.routers.contributors import router as contributors_router
 from app.routers.analytics import router as analytics_router
 from app.routers.scraper import router as scraper_router
+from app.routers.sync import router as sync_router
 
-__all__ = ["posts_router", "contributors_router", "analytics_router", "scraper_router"]
+__all__ = ["posts_router", "contributors_router", "analytics_router", "scraper_router", "sync_router"]

--- a/backend/app/routers/sync.py
+++ b/backend/app/routers/sync.py
@@ -1,0 +1,176 @@
+from datetime import datetime, timezone
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import Post, Contributor, ContributorReply
+from app.schemas import SyncRequest, SyncResponse
+from app.services.reddit_scraper import scraper
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/sync", tags=["sync"])
+
+
+@router.post("", response_model=SyncResponse)
+def sync_data(request: SyncRequest, db: Session = Depends(get_db)):
+    """
+    Sync posts, contributors, and contributor replies from a remote source.
+
+    Modes:
+    - sync: Add new records, update existing by ID (default)
+    - override: Delete all existing posts/replies, then insert new data
+
+    Process order: contributors -> posts -> contributor replies
+    """
+    errors: list[str] = []
+    posts_created = 0
+    posts_updated = 0
+    posts_deleted = 0
+    contributors_created = 0
+    contributors_updated = 0
+    replies_created = 0
+
+    try:
+        # In override mode, delete existing data first
+        if request.mode == "override":
+            # Delete in reverse order due to foreign key constraints
+            deleted_replies = db.query(ContributorReply).delete()
+            posts_deleted = db.query(Post).delete()
+            logger.info(f"Override mode: deleted {posts_deleted} posts and {deleted_replies} replies")
+
+        # 1. Process contributors first (for FK resolution)
+        contributor_map: dict[str, Contributor] = {}  # handle -> Contributor
+
+        if request.contributors:
+            for contrib_data in request.contributors:
+                handle_lower = contrib_data.reddit_handle.lower()
+                existing = db.query(Contributor).filter(
+                    Contributor.reddit_handle.ilike(contrib_data.reddit_handle)
+                ).first()
+
+                if existing:
+                    # Update existing contributor
+                    existing.name = contrib_data.name
+                    existing.role = contrib_data.role
+                    existing.active = contrib_data.active
+                    contributor_map[handle_lower] = existing
+                    contributors_updated += 1
+                else:
+                    # Create new contributor
+                    contributor = Contributor(
+                        name=contrib_data.name,
+                        reddit_handle=contrib_data.reddit_handle,
+                        role=contrib_data.role,
+                        active=contrib_data.active,
+                    )
+                    db.add(contributor)
+                    db.flush()  # Get the ID
+                    contributor_map[handle_lower] = contributor
+                    contributors_created += 1
+
+        # Build map of existing contributors for reply processing
+        all_contributors = db.query(Contributor).all()
+        for c in all_contributors:
+            contributor_map[c.reddit_handle.lower()] = c
+
+        # 2. Process posts
+        for post_data in request.posts:
+            existing = db.query(Post).filter(Post.id == post_data.id).first()
+
+            if existing:
+                # Update existing post
+                existing.subreddit = post_data.subreddit
+                existing.title = post_data.title
+                existing.body = post_data.body
+                existing.author = post_data.author
+                existing.url = post_data.url
+                existing.score = post_data.score
+                existing.num_comments = post_data.num_comments
+                existing.created_utc = post_data.created_utc
+                if post_data.scraped_at:
+                    existing.scraped_at = post_data.scraped_at
+                posts_updated += 1
+            else:
+                # Create new post
+                post = Post(
+                    id=post_data.id,
+                    subreddit=post_data.subreddit,
+                    title=post_data.title,
+                    body=post_data.body,
+                    author=post_data.author,
+                    url=post_data.url,
+                    score=post_data.score,
+                    num_comments=post_data.num_comments,
+                    created_utc=post_data.created_utc,
+                    scraped_at=post_data.scraped_at or datetime.now(timezone.utc),
+                )
+                db.add(post)
+                posts_created += 1
+
+        # 3. Process contributor replies
+        if request.contributor_replies:
+            for reply_data in request.contributor_replies:
+                # Look up contributor by handle
+                handle_lower = reply_data.contributor_handle.lower()
+                contributor = contributor_map.get(handle_lower)
+
+                if not contributor:
+                    errors.append(f"Contributor '{reply_data.contributor_handle}' not found for reply {reply_data.comment_id}")
+                    continue
+
+                # Check if post exists
+                post_exists = db.query(Post).filter(Post.id == reply_data.post_id).first()
+                if not post_exists:
+                    errors.append(f"Post '{reply_data.post_id}' not found for reply {reply_data.comment_id}")
+                    continue
+
+                # Check for existing reply by comment_id
+                existing_reply = db.query(ContributorReply).filter(
+                    ContributorReply.comment_id == reply_data.comment_id
+                ).first()
+
+                if not existing_reply:
+                    reply = ContributorReply(
+                        post_id=reply_data.post_id,
+                        contributor_id=contributor.id,
+                        comment_id=reply_data.comment_id,
+                        replied_at=reply_data.replied_at,
+                    )
+                    db.add(reply)
+                    replies_created += 1
+
+        # Update scraper status if source_scraped_at provided
+        if request.source_scraped_at:
+            scraper.last_run = request.source_scraped_at
+            scraper.posts_scraped = posts_created + posts_updated
+            logger.info(f"Updated scraper status: last_run={request.source_scraped_at}")
+
+        db.commit()
+
+        logger.info(
+            f"Sync completed: mode={request.mode}, "
+            f"posts_created={posts_created}, posts_updated={posts_updated}, "
+            f"posts_deleted={posts_deleted}, contributors_created={contributors_created}, "
+            f"contributors_updated={contributors_updated}, replies_created={replies_created}"
+        )
+
+        return SyncResponse(
+            success=True,
+            mode=request.mode,
+            posts_created=posts_created,
+            posts_updated=posts_updated,
+            posts_deleted=posts_deleted,
+            contributors_created=contributors_created,
+            contributors_updated=contributors_updated,
+            replies_created=replies_created,
+            synced_at=datetime.now(timezone.utc),
+            errors=errors,
+        )
+
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Sync failed: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Sync failed: {str(e)}")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -16,6 +16,13 @@ from app.schemas.schemas import (
     OverviewStats,
     SentimentTrend,
 )
+from app.schemas.sync import (
+    SyncPostData,
+    SyncContributorData,
+    SyncContributorReplyData,
+    SyncRequest,
+    SyncResponse,
+)
 
 __all__ = [
     "PostBase",
@@ -34,4 +41,9 @@ __all__ = [
     "ScrapeStatus",
     "OverviewStats",
     "SentimentTrend",
+    "SyncPostData",
+    "SyncContributorData",
+    "SyncContributorReplyData",
+    "SyncRequest",
+    "SyncResponse",
 ]

--- a/backend/app/schemas/sync.py
+++ b/backend/app/schemas/sync.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel
+from datetime import datetime
+from typing import Literal
+
+
+class SyncPostData(BaseModel):
+    """Post data for syncing."""
+    id: str  # Reddit post ID
+    subreddit: str
+    title: str
+    body: str | None = None
+    author: str
+    url: str
+    score: int = 0
+    num_comments: int = 0
+    created_utc: datetime
+    scraped_at: datetime | None = None
+
+
+class SyncContributorData(BaseModel):
+    """Contributor data for syncing."""
+    name: str
+    reddit_handle: str  # unique identifier
+    role: str | None = None
+    active: bool = True
+
+
+class SyncContributorReplyData(BaseModel):
+    """Contributor reply data for syncing."""
+    post_id: str
+    contributor_handle: str  # reference by handle, not ID
+    comment_id: str
+    replied_at: datetime
+
+
+class SyncRequest(BaseModel):
+    """Request payload for sync endpoint."""
+    mode: Literal["sync", "override"] = "sync"
+    source_scraped_at: datetime | None = None  # When source system last scraped
+    posts: list[SyncPostData]
+    contributors: list[SyncContributorData] | None = None
+    contributor_replies: list[SyncContributorReplyData] | None = None
+
+
+class SyncResponse(BaseModel):
+    """Response from sync endpoint."""
+    success: bool
+    mode: str
+    posts_created: int
+    posts_updated: int
+    posts_deleted: int = 0
+    contributors_created: int = 0
+    contributors_updated: int = 0
+    replies_created: int = 0
+    synced_at: datetime  # timestamp of when sync completed
+    errors: list[str] = []

--- a/backend/scripts/export_to_remote.py
+++ b/backend/scripts/export_to_remote.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+Export local database data and POST it to a remote Reddit Monitor instance.
+
+Usage:
+    # Sync all data to remote
+    python scripts/export_to_remote.py https://remote.example.com
+
+    # Only posts from last week
+    python scripts/export_to_remote.py https://remote.example.com --since 2025-01-19T00:00:00
+
+    # Full override (replace all remote data)
+    python scripts/export_to_remote.py https://remote.example.com --override
+
+    # Dry run (print payload without sending)
+    python scripts/export_to_remote.py https://remote.example.com --dry-run
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Post, Contributor, ContributorReply
+from app.services.reddit_scraper import scraper
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Export local DB data and sync to a remote Reddit Monitor instance"
+    )
+    parser.add_argument(
+        "remote_url",
+        help="Base URL of the remote API (e.g., https://remote.example.com)",
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        help="Only export posts created after this timestamp (ISO format, e.g., 2025-01-19T00:00:00)",
+    )
+    parser.add_argument(
+        "--override",
+        action="store_true",
+        help="Use override mode (replace all remote data)",
+    )
+    parser.add_argument(
+        "--no-contributors",
+        action="store_true",
+        help="Exclude contributors from export",
+    )
+    parser.add_argument(
+        "--no-replies",
+        action="store_true",
+        help="Exclude contributor replies from export",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print payload without sending",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Request timeout in seconds (default: 60)",
+    )
+    return parser.parse_args()
+
+
+def get_db_session():
+    """Create a database session using the same DB as the app."""
+    db_path = Path(__file__).parent.parent / "data" / "reddit_monitor.db"
+    if not db_path.exists():
+        print(f"Error: Database not found at {db_path}")
+        sys.exit(1)
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def export_posts(db, since: datetime | None = None) -> list[dict]:
+    """Export posts from the database."""
+    query = db.query(Post)
+    if since:
+        query = query.filter(Post.created_utc >= since)
+
+    posts = query.order_by(Post.created_utc.desc()).all()
+
+    return [
+        {
+            "id": post.id,
+            "subreddit": post.subreddit,
+            "title": post.title,
+            "body": post.body,
+            "author": post.author,
+            "url": post.url,
+            "score": post.score,
+            "num_comments": post.num_comments,
+            "created_utc": post.created_utc.isoformat() if post.created_utc else None,
+            "scraped_at": post.scraped_at.isoformat() if post.scraped_at else None,
+        }
+        for post in posts
+    ]
+
+
+def export_contributors(db) -> list[dict]:
+    """Export contributors from the database."""
+    contributors = db.query(Contributor).all()
+
+    return [
+        {
+            "name": contrib.name,
+            "reddit_handle": contrib.reddit_handle,
+            "role": contrib.role,
+            "active": contrib.active,
+        }
+        for contrib in contributors
+    ]
+
+
+def export_replies(db, post_ids: set[str] | None = None) -> list[dict]:
+    """Export contributor replies from the database."""
+    query = db.query(ContributorReply).join(Contributor)
+
+    if post_ids:
+        query = query.filter(ContributorReply.post_id.in_(post_ids))
+
+    replies = query.all()
+
+    return [
+        {
+            "post_id": reply.post_id,
+            "contributor_handle": reply.contributor.reddit_handle,
+            "comment_id": reply.comment_id,
+            "replied_at": reply.replied_at.isoformat() if reply.replied_at else None,
+        }
+        for reply in replies
+    ]
+
+
+def main():
+    args = parse_args()
+
+    # Parse since timestamp if provided
+    since = None
+    if args.since:
+        try:
+            since = datetime.fromisoformat(args.since)
+            if since.tzinfo is None:
+                since = since.replace(tzinfo=timezone.utc)
+        except ValueError:
+            print(f"Error: Invalid timestamp format: {args.since}")
+            print("Expected ISO format, e.g., 2025-01-19T00:00:00")
+            sys.exit(1)
+
+    # Get database session
+    db = get_db_session()
+
+    try:
+        # Export data
+        print("Exporting data from local database...")
+
+        posts = export_posts(db, since)
+        print(f"  Posts: {len(posts)}")
+
+        contributors = None
+        if not args.no_contributors:
+            contributors = export_contributors(db)
+            print(f"  Contributors: {len(contributors)}")
+
+        replies = None
+        if not args.no_replies:
+            post_ids = {p["id"] for p in posts} if since else None
+            replies = export_replies(db, post_ids)
+            print(f"  Contributor replies: {len(replies)}")
+
+        # Build payload
+        payload = {
+            "mode": "override" if args.override else "sync",
+            "posts": posts,
+        }
+
+        # Include source_scraped_at from local scraper
+        if scraper.last_run:
+            payload["source_scraped_at"] = scraper.last_run.isoformat()
+
+        if contributors is not None:
+            payload["contributors"] = contributors
+
+        if replies is not None:
+            payload["contributor_replies"] = replies
+
+        # Dry run - print payload
+        if args.dry_run:
+            print("\n--- DRY RUN ---")
+            print(f"Would POST to: {args.remote_url}/api/sync")
+            print(f"Mode: {payload['mode']}")
+            print(f"Posts: {len(posts)}")
+            if contributors is not None:
+                print(f"Contributors: {len(contributors)}")
+            if replies is not None:
+                print(f"Contributor replies: {len(replies)}")
+            print("\nPayload preview (first 2 posts):")
+            preview = {**payload, "posts": posts[:2]}
+            print(json.dumps(preview, indent=2, default=str))
+            return
+
+        # Send to remote
+        url = f"{args.remote_url.rstrip('/')}/api/sync"
+        print(f"\nSending to {url}...")
+
+        with httpx.Client(timeout=args.timeout) as client:
+            response = client.post(url, json=payload)
+            response.raise_for_status()
+            result = response.json()
+
+        print("\n--- Sync completed ---")
+        print(f"Success: {result.get('success')}")
+        print(f"Mode: {result.get('mode')}")
+        print(f"Posts created: {result.get('posts_created')}")
+        print(f"Posts updated: {result.get('posts_updated')}")
+        if result.get('posts_deleted'):
+            print(f"Posts deleted: {result.get('posts_deleted')}")
+        if result.get('contributors_created'):
+            print(f"Contributors created: {result.get('contributors_created')}")
+        if result.get('contributors_updated'):
+            print(f"Contributors updated: {result.get('contributors_updated')}")
+        if result.get('replies_created'):
+            print(f"Replies created: {result.get('replies_created')}")
+        print(f"Synced at: {result.get('synced_at')}")
+
+        if result.get('errors'):
+            print(f"\nWarnings/Errors:")
+            for error in result['errors']:
+                print(f"  - {error}")
+
+    except httpx.HTTPStatusError as e:
+        print(f"Error: HTTP {e.response.status_code}")
+        try:
+            detail = e.response.json().get('detail', e.response.text)
+            print(f"Detail: {detail}")
+        except Exception:
+            print(f"Response: {e.response.text}")
+        sys.exit(1)
+    except httpx.RequestError as e:
+        print(f"Error: Failed to connect to {args.remote_url}")
+        print(f"Detail: {str(e)}")
+        sys.exit(1)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -3,17 +3,15 @@
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import {
   getOverviewStats,
   getScrapeStatus,
-  triggerScrape,
   getWarningPosts,
   type OverviewStats,
   type ScrapeStatus,
   type WarningPost,
 } from "@/lib/api"
-import { RefreshCw, FileText, AlertTriangle, CheckCircle, Clock, AlertCircle, UserCheck } from "lucide-react"
+import { FileText, AlertTriangle, CheckCircle, Clock, AlertCircle, UserCheck } from "lucide-react"
 import { formatRelativeTime } from "@/lib/utils"
 import Link from "next/link"
 
@@ -23,7 +21,6 @@ export function Dashboard() {
   const [scrapeStatus, setScrapeStatus] = useState<ScrapeStatus | null>(null)
   const [warningPosts, setWarningPosts] = useState<WarningPost[]>([])
   const [loading, setLoading] = useState(true)
-  const [scraping, setScraping] = useState(false)
 
   useEffect(() => {
     loadData()
@@ -54,47 +51,17 @@ export function Dashboard() {
     }
   }
 
-  async function loadScrapeStatus() {
-    try {
-      const statusData = await getScrapeStatus()
-      setScrapeStatus(statusData)
-    } catch (error) {
-      console.error("Failed to load scrape status:", error)
-    }
-  }
-
-  async function handleScrape() {
-    setScraping(true)
-    try {
-      await triggerScrape({ time_range: "week" })
-      await loadScrapeStatus()
-    } catch (error) {
-      console.error("Failed to trigger scrape:", error)
-    } finally {
-      setScraping(false)
-    }
-  }
-
   if (loading) {
     return <div className="p-8 text-center">Loading dashboard...</div>
   }
 
   return (
     <div className="p-8 space-y-8">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Dashboard</h1>
-          <p className="text-muted-foreground">
-            Monitor Copilot Studio discussions on Reddit
-          </p>
-        </div>
-        <Button
-          onClick={handleScrape}
-          disabled={scraping || scrapeStatus?.is_running}
-        >
-          <RefreshCw className={`h-4 w-4 mr-2 ${scrapeStatus?.is_running ? "animate-spin" : ""}`} />
-          {scrapeStatus?.is_running ? "Scraping..." : "Scrape Now"}
-        </Button>
+      <div>
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <p className="text-muted-foreground">
+          Monitor Copilot Studio discussions on Reddit
+        </p>
       </div>
 
       {/* Stats cards */}


### PR DESCRIPTION
## Summary
- Add `POST /api/sync` endpoint with sync/override modes for receiving posts, contributors, and contributor replies from remote sources
- Create `export_to_remote.py` script to export local DB and POST to remote instance
- Remove scrape button from Dashboard (scraping still works via API and scheduler)

## Test plan
- [ ] Start backend, verify `/api/sync` endpoint appears in `/docs`
- [ ] Test sync endpoint with curl: `curl -X POST http://localhost:8000/api/sync -H "Content-Type: application/json" -d '{"posts": []}'`
- [ ] Test export script dry-run: `python scripts/export_to_remote.py http://localhost:8000 --dry-run`
- [ ] Verify Dashboard loads without scrape button
- [ ] Verify scraper status card still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)