### PR TITLE
Add data freshness display for synced data

### DIFF
--- a/backend/app/routers/scraper.py
+++ b/backend/app/routers/scraper.py
@@ -70,6 +70,9 @@ def get_scrape_status():
         last_run=status["last_run"],
         posts_scraped=status["posts_scraped"],
         errors=status["errors"],
+        last_synced_at=status["last_synced_at"],
+        last_sync_source_scraped_at=status["last_sync_source_scraped_at"],
+        last_sync_posts=status["last_sync_posts"],
     )
 
 

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -119,6 +119,10 @@ class ScrapeStatus(BaseModel):
     last_run: datetime | None = None
     posts_scraped: int = 0
     errors: list[str] = []
+    # Sync info (for destination servers receiving synced data)
+    last_synced_at: datetime | None = None
+    last_sync_source_scraped_at: datetime | None = None
+    last_sync_posts: int = 0
 
 
 # Analytics schemas

--- a/backend/app/services/reddit_scraper.py
+++ b/backend/app/services/reddit_scraper.py
@@ -24,6 +24,10 @@ class RedditScraper:
         self.base_url = "https://www.reddit.com"
         self.headers = {"User-Agent": self.settings.reddit_user_agent}
         self.subreddit = "CopilotStudio"
+        # Sync tracking
+        self.last_synced_at: datetime | None = None
+        self.last_sync_source_scraped_at: datetime | None = None
+        self.last_sync_posts: int = 0
 
     def scrape(
         self,
@@ -274,6 +278,10 @@ class RedditScraper:
             "last_run": self.last_run,
             "posts_scraped": self.posts_scraped,
             "errors": self.errors,
+            # Sync info
+            "last_synced_at": self.last_synced_at,
+            "last_sync_source_scraped_at": self.last_sync_source_scraped_at,
+            "last_sync_posts": self.last_sync_posts,
         }
 
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -190,28 +190,46 @@ export function Dashboard() {
         </Card>
       )}
 
-      {/* Scrape status */}
+      {/* Scrape/Sync status */}
       {scrapeStatus && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Scraper Status</CardTitle>
+            <CardTitle className="text-lg">Data Freshness</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-2">
+            <div className="space-y-3">
               <div className="flex items-center gap-2">
                 <span className={`h-2 w-2 rounded-full ${scrapeStatus.is_running ? "bg-green-500 animate-pulse" : "bg-gray-300"}`} />
-                <span>{scrapeStatus.is_running ? "Running" : "Idle"}</span>
+                <span>{scrapeStatus.is_running ? "Scraping..." : "Idle"}</span>
               </div>
+
+              {/* Show scrape info */}
               {scrapeStatus.last_run && (
-                <p className="text-sm text-muted-foreground">
-                  Last run: {new Date(scrapeStatus.last_run).toLocaleString()}
-                </p>
+                <div className="text-sm">
+                  <p className="font-medium">Last scraped</p>
+                  <p className="text-muted-foreground">
+                    {new Date(scrapeStatus.last_run).toLocaleString()}
+                    {scrapeStatus.posts_scraped > 0 && ` (${scrapeStatus.posts_scraped} posts)`}
+                  </p>
+                </div>
               )}
-              {scrapeStatus.posts_scraped > 0 && (
-                <p className="text-sm text-muted-foreground">
-                  Posts scraped in last run: {scrapeStatus.posts_scraped}
-                </p>
+
+              {/* Show sync info if this server received synced data */}
+              {scrapeStatus.last_synced_at && (
+                <div className="text-sm border-t pt-2">
+                  <p className="font-medium">Last synced</p>
+                  <p className="text-muted-foreground">
+                    Received: {new Date(scrapeStatus.last_synced_at).toLocaleString()}
+                    {scrapeStatus.last_sync_posts > 0 && ` (${scrapeStatus.last_sync_posts} posts)`}
+                  </p>
+                  {scrapeStatus.last_sync_source_scraped_at && (
+                    <p className="text-muted-foreground">
+                      Source scraped: {new Date(scrapeStatus.last_sync_source_scraped_at).toLocaleString()}
+                    </p>
+                  )}
+                </div>
               )}
+
               {scrapeStatus.errors.length > 0 && (
                 <div className="text-sm text-red-500">
                   Errors: {scrapeStatus.errors.join(", ")}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,10 @@ export interface ScrapeStatus {
   last_run: string | null
   posts_scraped: number
   errors: string[]
+  // Sync info (for destination servers receiving synced data)
+  last_synced_at: string | null
+  last_sync_source_scraped_at: string | null
+  last_sync_posts: number
 }
 
 export interface OverviewStats {


### PR DESCRIPTION
## Summary
- Add sync tracking fields to scraper singleton to track when data was synced and when source originally scraped
- Update Dashboard "Scraper Status" card to "Data Freshness" showing both scrape and sync timestamps
- Destination servers now display when they received data and when the source system scraped it

## Test plan
- [ ] Verify Dashboard shows "Data Freshness" card with last scraped time
- [ ] Run sync with `source_scraped_at` parameter and verify both sync timestamps appear
- [ ] Verify `GET /api/scrape/status` returns new sync fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)