### PR TITLE
Improve boiling posts UX and fix auth config sync

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -93,3 +93,13 @@ def health_check():
         "status": "healthy",
         "scheduler_running": scheduler_service.is_running,
     }
+
+
+@app.get("/api/config")
+def get_config():
+    """Get public configuration (no auth required)."""
+    from app.config import get_settings
+    settings = get_settings()
+    return {
+        "auth_enabled": settings.auth_enabled,
+    }

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useAuth } from "@/lib/auth-context"
-import { isAuthConfigured } from "@/lib/msal-config"
 import { Button } from "@/components/ui/button"
 import { LogIn } from "lucide-react"
 
@@ -10,10 +9,10 @@ interface AuthGateProps {
 }
 
 export function AuthGate({ children }: AuthGateProps) {
-  const { isAuthenticated, isLoading, login } = useAuth()
+  const { isAuthenticated, isLoading, authEnabled, login } = useAuth()
 
-  // If auth is not configured, just render children (dev mode without auth)
-  if (!isAuthConfigured) {
+  // If auth is not enabled (frontend not configured OR backend has auth disabled), just render children
+  if (!authEnabled) {
     return <>{children}</>
   }
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -22,6 +22,7 @@ export function Dashboard() {
   const [stats, setStats] = useState<OverviewStats | null>(null)
   const [scrapeStatus, setScrapeStatus] = useState<ScrapeStatus | null>(null)
   const [warningPosts, setWarningPosts] = useState<WarningPost[]>([])
+  const [totalWarningCount, setTotalWarningCount] = useState(0)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -41,11 +42,12 @@ export function Dashboard() {
       const [statsData, statusData, warnings] = await Promise.all([
         getOverviewStats(),
         getScrapeStatus(),
-        getWarningPosts(5),
+        getWarningPosts(50, true),
       ])
       setStats(statsData)
       setScrapeStatus(statusData)
-      setWarningPosts(warnings)
+      setTotalWarningCount(warnings.length)
+      setWarningPosts(warnings.slice(0, 5))
     } catch (error) {
       console.error("Failed to load dashboard data:", error)
     } finally {
@@ -152,14 +154,23 @@ export function Dashboard() {
       </div>
 
       {/* Boiling Posts tile */}
-      {warningPosts.length > 0 && (
+      {totalWarningCount > 0 && (
         <Card className="border-orange-200 bg-orange-50/50">
           <CardHeader className="pb-3">
             <div className="flex items-center justify-between">
               <CardTitle className="text-lg flex items-center gap-2">
                 <AlertCircle className="h-5 w-5 text-orange-600" />
-                Boiling Posts ({warningPosts.length})
+                Boiling Posts
+                <span className="text-sm font-normal text-muted-foreground">
+                  ({warningPosts.length} of {totalWarningCount})
+                </span>
               </CardTitle>
+              <Link
+                href="/posts?sentiment=negative"
+                className="text-sm text-orange-600 hover:text-orange-800 hover:underline"
+              >
+                View all negative →
+              </Link>
             </div>
           </CardHeader>
           <CardContent>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -15,14 +15,14 @@ import { User, ChevronDown, Check, LogIn, LogOut, Copy } from "lucide-react"
 
 export function Header() {
   const { contributor, contributors, setContributor, loading } = useContributor()
-  const { user, isAuthenticated, isLoading: authLoading, login, logout, getAccessToken } = useAuth()
+  const { user, isAuthenticated, isLoading: authLoading, authEnabled, login, logout, getAccessToken } = useAuth()
 
   return (
     <header className="h-14 border-b bg-card flex items-center justify-end px-6 gap-4">
-      {/* Auth section */}
-      {authLoading ? (
+      {/* Auth section - only show if auth is enabled on backend */}
+      {authEnabled && authLoading ? (
         <span className="text-sm text-muted-foreground">Loading...</span>
-      ) : isAuthenticated && user ? (
+      ) : authEnabled && isAuthenticated && user ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" className="flex items-center gap-2">
@@ -75,15 +75,15 @@ export function Header() {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      ) : (
+      ) : authEnabled ? (
         <Button variant="outline" size="sm" onClick={login} className="flex items-center gap-2">
           <LogIn className="h-4 w-4" />
           Sign in with Microsoft
         </Button>
-      )}
+      ) : null}
 
-      {/* Contributor selector - only show if not using auth or auth is not configured */}
-      {!isAuthenticated && (
+      {/* Contributor selector - show if auth disabled OR authenticated but not linked to a contributor */}
+      {(!authEnabled || (isAuthenticated && !user?.contributorId)) && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" className="flex items-center gap-2">

--- a/frontend/src/components/SentimentBadge.tsx
+++ b/frontend/src/components/SentimentBadge.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Badge } from "@/components/ui/badge"
+import { Flame } from "lucide-react"
 
 interface SentimentBadgeProps {
   sentiment: "positive" | "neutral" | "negative" | null
@@ -23,8 +24,8 @@ export function SentimentBadge({ sentiment, score, showScore = false, isWarning 
   return (
     <div className="flex items-center gap-1.5">
       {isWarning && (
-        <Badge variant="warning" className="px-1.5">
-          ⚠
+        <Badge variant="warning" className="px-1.5 flex items-center gap-1">
+          <Flame className="h-3 w-3" />
         </Badge>
       )}
       <Badge variant={variant}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -254,8 +254,11 @@ export interface WarningPost {
   summary: string | null
 }
 
-export async function getWarningPosts(limit?: number): Promise<WarningPost[]> {
-  const query = limit ? `?limit=${limit}` : ""
+export async function getWarningPosts(limit?: number, withoutReply?: boolean): Promise<WarningPost[]> {
+  const params = new URLSearchParams()
+  if (limit) params.set("limit", limit.toString())
+  if (withoutReply) params.set("without_reply", "true")
+  const query = params.toString() ? `?${params.toString()}` : ""
   return fetchApi<WarningPost[]>(`/api/analytics/warnings${query}`)
 }
 


### PR DESCRIPTION
## Summary
- **Boiling Posts UX**: Only show actionable posts (no MS response), add count indicator, drill-down link, and flame icon
- **Auth Config Sync**: Frontend now checks backend `/api/config` before showing sign-in UI

## Changes

### Boiling Posts
- Only show posts without MS response (truly actionable items)
- Show "(5 of 10)" count indicator when there are more posts
- Add "View all negative →" link to drill down to posts page with sentiment filter
- Replace warning triangle with Flame icon for boiling badge

### Auth Config
- Add `/api/config` endpoint returning `{ auth_enabled: true/false }`
- Frontend fetches backend config before initializing MSAL
- If backend has `auth_enabled=false`, only contributor picker is shown (no sign-in button or login gate)
- Fixes confusing state when frontend has auth configured but backend doesn't

## Test plan
- [ ] Verify boiling posts tile shows "(X of Y)" count
- [ ] Verify "View all negative →" links to `/posts?sentiment=negative`
- [ ] Verify flame icon appears on boiling posts in list
- [ ] With backend `auth_enabled=false`: verify no sign-in UI, only contributor picker
- [ ] With backend `auth_enabled=true`: verify sign-in flow works

Addresses #19

🤖 Generated with [Claude Code](https://claude.ai/code)