### PR TITLE
Add contributor activity analytics page

### DIFF
--- a/frontend/src/app/contributors/detail/page.tsx
+++ b/frontend/src/app/contributors/detail/page.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useEffect, useState, Suspense } from "react"
+import { useSearchParams, useRouter } from "next/navigation"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  getContributors,
+  getContributorActivity,
+  type Contributor,
+  type ContributorActivity,
+} from "@/lib/api"
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { ArrowLeft, MessageSquare, Calendar, TrendingUp } from "lucide-react"
+import Link from "next/link"
+import { formatRelativeTime } from "@/lib/utils"
+
+export default function ContributorDetailPage() {
+  return (
+    <Suspense fallback={<div className="p-8 text-center">Loading...</div>}>
+      <ContributorDetailContent />
+    </Suspense>
+  )
+}
+
+function ContributorDetailContent() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const contributorId = searchParams.get("id")
+
+  const [contributors, setContributors] = useState<Contributor[]>([])
+  const [selectedId, setSelectedId] = useState<string>(contributorId || "")
+  const [activity, setActivity] = useState<ContributorActivity | null>(null)
+  const [days, setDays] = useState("90")
+  const [loading, setLoading] = useState(true)
+
+  // Load contributors list for dropdown
+  useEffect(() => {
+    async function loadContributors() {
+      try {
+        const data = await getContributors()
+        setContributors(data)
+      } catch (error) {
+        console.error("Failed to load contributors:", error)
+      }
+    }
+    loadContributors()
+  }, [])
+
+  // Load activity when contributor or days changes
+  useEffect(() => {
+    if (!selectedId) {
+      setLoading(false)
+      return
+    }
+
+    async function loadActivity() {
+      setLoading(true)
+      try {
+        const data = await getContributorActivity(parseInt(selectedId), parseInt(days))
+        setActivity(data)
+      } catch (error) {
+        console.error("Failed to load activity:", error)
+        setActivity(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadActivity()
+  }, [selectedId, days])
+
+  function handleContributorChange(value: string) {
+    setSelectedId(value)
+    router.push(`/contributors/detail?id=${value}`)
+  }
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push("/contributors")}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Contributor Activity</h1>
+          <p className="text-muted-foreground">
+            Response history and engagement metrics
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Select value={selectedId} onValueChange={handleContributorChange}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Select contributor" />
+            </SelectTrigger>
+            <SelectContent>
+              {contributors.map((c) => (
+                <SelectItem key={c.id} value={c.id.toString()}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={days} onValueChange={setDays}>
+            <SelectTrigger className="w-[140px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="30">Last 30 days</SelectItem>
+              <SelectItem value="60">Last 60 days</SelectItem>
+              <SelectItem value="90">Last 90 days</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {!selectedId ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            Select a contributor to view their activity
+          </CardContent>
+        </Card>
+      ) : loading ? (
+        <div className="text-center py-12">Loading activity...</div>
+      ) : !activity ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            Could not load activity data
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Summary Stats */}
+          <div className="grid gap-4 md:grid-cols-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Today</CardTitle>
+                <Calendar className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{activity.summary.replies_today}</div>
+                <p className="text-xs text-muted-foreground">replies</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">This Week</CardTitle>
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{activity.summary.replies_week}</div>
+                <p className="text-xs text-muted-foreground">replies</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">This Month</CardTitle>
+                <TrendingUp className="h-4 w-4 text-blue-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{activity.summary.replies_month}</div>
+                <p className="text-xs text-muted-foreground">replies</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">All Time</CardTitle>
+                <MessageSquare className="h-4 w-4 text-green-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{activity.summary.replies_total}</div>
+                <p className="text-xs text-muted-foreground">total replies</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Activity Chart */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Reply Activity</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {activity.activity.length === 0 ? (
+                <div className="h-[300px] flex items-center justify-center text-muted-foreground">
+                  No activity in this period
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height={300}>
+                  <BarChart data={activity.activity}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={(value) => {
+                        const date = new Date(value)
+                        return `${date.getMonth() + 1}/${date.getDate()}`
+                      }}
+                    />
+                    <YAxis allowDecimals={false} />
+                    <Tooltip
+                      labelFormatter={(value) => new Date(value).toLocaleDateString()}
+                      formatter={(value: number) => [value, "Replies"]}
+                    />
+                    <Bar dataKey="count" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Recent Posts */}
+          {activity.recent_posts.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Recent Responses</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {activity.recent_posts.map((post) => (
+                    <Link
+                      key={post.post_id}
+                      href={`/posts/detail?id=${post.post_id}`}
+                      className="block p-3 rounded-lg border hover:bg-accent transition-colors"
+                    >
+                      <p className="font-medium line-clamp-1">{post.title}</p>
+                      <p className="text-sm text-muted-foreground">
+                        Replied {formatRelativeTime(post.replied_at)}
+                      </p>
+                    </Link>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ContributorList.tsx
+++ b/frontend/src/components/ContributorList.tsx
@@ -11,7 +11,8 @@ import {
   type Contributor,
 } from "@/lib/api"
 import { formatDate } from "@/lib/utils"
-import { Plus, Trash2, User } from "lucide-react"
+import { Plus, Trash2, User, BarChart3 } from "lucide-react"
+import Link from "next/link"
 
 interface ContributorListProps {
   contributors: Contributor[]
@@ -135,7 +136,12 @@ export function ContributorList({ contributors, onUpdate }: ContributorListProps
                       <User className="h-5 w-5 text-primary" />
                     </div>
                     <div>
-                      <p className="font-medium">{contributor.name}</p>
+                      <Link
+                        href={`/contributors/detail?id=${contributor.id}`}
+                        className="font-medium hover:text-primary hover:underline"
+                      >
+                        {contributor.name}
+                      </Link>
                       <p className="text-sm text-muted-foreground">
                         u/{contributor.reddit_handle}
                       </p>
@@ -150,11 +156,20 @@ export function ContributorList({ contributors, onUpdate }: ContributorListProps
                     <Trash2 className="h-4 w-4" />
                   </Button>
                 </div>
-                <div className="mt-4 flex items-center gap-2">
-                  {contributor.role && (
-                    <Badge variant="secondary">{contributor.role}</Badge>
-                  )}
-                  <Badge variant="outline">{contributor.reply_count} replies</Badge>
+                <div className="mt-4 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    {contributor.role && (
+                      <Badge variant="secondary">{contributor.role}</Badge>
+                    )}
+                    <Badge variant="outline">{contributor.reply_count} replies</Badge>
+                  </div>
+                  <Link
+                    href={`/contributors/detail?id=${contributor.id}`}
+                    className="text-muted-foreground hover:text-primary"
+                    title="View activity"
+                  >
+                    <BarChart3 className="h-4 w-4" />
+                  </Link>
                 </div>
                 <p className="text-xs text-muted-foreground mt-2">
                   Added {formatDate(contributor.created_at)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -224,6 +224,34 @@ export async function deleteContributor(id: number): Promise<void> {
   await fetchApi(`/api/contributors/${id}`, { method: "DELETE" })
 }
 
+export interface ContributorActivity {
+  contributor: {
+    id: number
+    name: string
+    reddit_handle: string
+  }
+  activity: { date: string; count: number }[]
+  summary: {
+    replies_today: number
+    replies_week: number
+    replies_month: number
+    replies_total: number
+  }
+  recent_posts: {
+    post_id: string
+    title: string
+    replied_at: string
+  }[]
+}
+
+export async function getContributorActivity(
+  id: number,
+  days?: number
+): Promise<ContributorActivity> {
+  const query = days ? `?days=${days}` : ""
+  return fetchApi<ContributorActivity>(`/api/contributors/${id}/activity${query}`)
+}
+
 // Analytics
 export async function getOverviewStats(): Promise<OverviewStats> {
   return fetchApi<OverviewStats>("/api/analytics/overview")


### PR DESCRIPTION
## Summary
- Added `/contributors/detail` page with contributor activity analytics
- Shows daily reply activity chart (recharts BarChart)
- Summary stats: today, this week, this month, all time
- Recent responses list with links to posts
- Contributor dropdown to switch between contributors
- Time period filter (30/60/90 days)
- Made contributor names clickable in the list to navigate to analytics

Closes #16

## Test plan
- [x] Build passes
- [x] All 40 E2E tests pass
- [x] Click contributor name → navigates to analytics page
- [x] Chart displays correctly with data
- [x] Dropdown allows switching contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)