### PR TITLE
Fix empty dashboard after sign-in race condition

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -18,16 +18,20 @@ import { useAuth } from "@/lib/auth-context"
 
 export function Dashboard() {
   const router = useRouter()
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
   const [stats, setStats] = useState<OverviewStats | null>(null)
   const [scrapeStatus, setScrapeStatus] = useState<ScrapeStatus | null>(null)
   const [warningPosts, setWarningPosts] = useState<WarningPost[]>([])
   const [totalWarningCount, setTotalWarningCount] = useState(0)
   const [loading, setLoading] = useState(true)
 
+  // Wait for auth to be fully initialized before fetching data
+  // This prevents race condition where loadData fires before token getter is registered
   useEffect(() => {
-    loadData()
-  }, [isAuthenticated])
+    if (!authLoading) {
+      loadData()
+    }
+  }, [isAuthenticated, authLoading])
 
   // Auto-refresh while scraping is running
   useEffect(() => {

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -113,6 +113,10 @@ function AuthProviderInner({ children, backendAuthEnabled }: { children: ReactNo
         return
       }
 
+      // Reset loading state when starting to fetch user info after sign-in
+      // This ensures AuthGate shows loading spinner while we set up the token getter
+      setIsLoading(true)
+
       try {
         const token = await getAccessToken()
         if (!token) {

--- a/frontend/src/lib/contributor-context.tsx
+++ b/frontend/src/lib/contributor-context.tsx
@@ -25,13 +25,16 @@ const ContributorContext = createContext<ContributorContextType | undefined>(
 )
 
 export function ContributorProvider({ children }: { children: ReactNode }) {
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth()
   const [contributor, setContributorState] = useState<Contributor | null>(null)
   const [contributors, setContributors] = useState<Contributor[]>([])
   const [loading, setLoading] = useState(true)
   const [isAutoLinked, setIsAutoLinked] = useState(false)
 
   useEffect(() => {
+    // Wait for auth to be fully initialized before fetching contributors
+    if (authLoading) return
+
     async function loadContributors() {
       try {
         const data = await getContributors()
@@ -66,7 +69,7 @@ export function ContributorProvider({ children }: { children: ReactNode }) {
     }
 
     loadContributors()
-  }, [isAuthenticated, user?.contributorId])
+  }, [isAuthenticated, authLoading, user?.contributorId])
 
   function setContributor(contributor: Contributor | null) {
     // Don't allow changing if auto-linked via auth


### PR DESCRIPTION
## Summary
- Fixed race condition where dashboard was empty after sign-in until page refresh
- Root cause: `loadData()` fired before the token getter was registered in auth context
- Reset `isLoading` to true when sign-in completes to show loading spinner while token getter is set up
- Dashboard and ContributorProvider now wait for auth to be fully initialized before fetching data

## Test plan
- [ ] Sign out of the app
- [ ] Sign in via Microsoft popup
- [ ] Verify dashboard shows data immediately (no refresh needed)
- [ ] Verify contributors load correctly after sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)