### PR TITLE
Replace confusing Handled badge with separate status indicators

### DIFF
--- a/frontend/src/app/posts/page.tsx
+++ b/frontend/src/app/posts/page.tsx
@@ -138,7 +138,7 @@ function PostsContent() {
               <SelectItem value="all">All Posts</SelectItem>
               <SelectItem value="waiting_for_pickup">Waiting for Pickup</SelectItem>
               <SelectItem value="in_progress">In Progress</SelectItem>
-              <SelectItem value="handled">Handled</SelectItem>
+              <SelectItem value="handled">Completed</SelectItem>
               {contributor && (
                 <SelectItem value="my_checkouts">My Checkouts</SelectItem>
               )}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -127,13 +127,13 @@ export function Dashboard() {
           onClick={() => router.push("/posts?status=handled")}
         >
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Handled</CardTitle>
+            <CardTitle className="text-sm font-medium">Completed</CardTitle>
             <CheckCircle className="h-4 w-4 text-green-500" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{stats?.handled_count || 0}</div>
             <p className="text-xs text-muted-foreground">
-              responded or resolved
+              MS response or resolved
             </p>
           </CardContent>
         </Card>

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -102,10 +102,16 @@ export function PostCard({ post, onPostUpdate }: PostCardProps) {
                 {post.checked_out_by_name}
               </Badge>
             )}
-            {(post.has_contributor_reply || post.resolved) && (
+            {post.has_contributor_reply && (
               <Badge className="bg-green-100 text-green-800">
                 <CheckCircle className="h-3 w-3 mr-1" />
-                Handled
+                MS Response
+              </Badge>
+            )}
+            {post.resolved && (
+              <Badge className="bg-purple-100 text-purple-800">
+                <CheckCircle className="h-3 w-3 mr-1" />
+                Resolved
               </Badge>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Replace single "Handled" badge with separate **MS Response** (green) and **Resolved** (purple) badges on post cards
- Rename Dashboard card from "Handled" to "Completed" with subtitle "MS response or resolved"
- Rename filter dropdown option from "Handled" to "Completed"

## Why
The previous "Handled" badge was confusing because it conflated two distinct concepts:
- **MS Response**: Automatic detection when a Microsoft employee replies on Reddit
- **Resolved**: Manual workflow action when a contributor marks a post as done

## Test plan
- [ ] View posts list with filter "Completed" - verify posts show appropriate badges
- [ ] Find a post with both MS response AND resolved - verify both badges appear
- [ ] Check Dashboard "Completed" card shows correct count
- [ ] Verify badge colors match: MS Response (green), Resolved (purple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)