### PR TITLE
Add product area filter and Mark Done button to posts page

### DIFF
--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -60,6 +60,9 @@ class PostResponse(PostBase):
     resolved_at: datetime | None = None
     resolved_by: int | None = None
     resolved_by_name: str | None = None
+    # Product area from latest analysis
+    product_area_id: int | None = None
+    product_area_name: str | None = None
 
     class Config:
         from_attributes = True

--- a/frontend/src/app/posts/page.tsx
+++ b/frontend/src/app/posts/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import { useEffect, useState, useCallback, useRef, Suspense } from "react"
-import { useSearchParams } from "next/navigation"
+import { useSearchParams, useRouter } from "next/navigation"
 import { PostCard } from "@/components/PostCard"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
 import {
   Select,
   SelectContent,
@@ -12,9 +13,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { getPosts, type Post } from "@/lib/api"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { getPosts, getProductAreas, type Post, type ProductArea } from "@/lib/api"
 import { useContributor } from "@/lib/contributor-context"
-import { RefreshCw } from "lucide-react"
+import { RefreshCw, Check, X } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 export default function PostsPage() {
   return (
@@ -24,8 +31,95 @@ export default function PostsPage() {
   )
 }
 
+function ProductAreaFilter({
+  options,
+  selected,
+  onChange,
+  postCounts,
+}: {
+  options: ProductArea[]
+  selected: number[]
+  onChange: (ids: number[]) => void
+  postCounts: Record<number, number>
+}) {
+  const [open, setOpen] = useState(false)
+
+  const toggleOption = (id: number) => {
+    if (selected.includes(id)) {
+      onChange(selected.filter((s) => s !== id))
+    } else {
+      onChange([...selected, id])
+    }
+  }
+
+  const selectedNames = options
+    .filter((o) => selected.includes(o.id))
+    .map((o) => o.name)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="min-w-[200px] justify-start"
+        >
+          {selected.length === 0 ? (
+            <span className="text-muted-foreground">Filter by product area</span>
+          ) : selected.length === 1 ? (
+            <span className="truncate">{selectedNames[0]}</span>
+          ) : (
+            <span>{selected.length} areas selected</span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0" align="start">
+        <div className="max-h-[300px] overflow-y-auto">
+          {options.map((option) => {
+            const isSelected = selected.includes(option.id)
+            const count = postCounts[option.id] || 0
+            return (
+              <button
+                key={option.id}
+                onClick={() => toggleOption(option.id)}
+                className={cn(
+                  "w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-accent text-left",
+                  isSelected && "bg-accent/50"
+                )}
+              >
+                <div className={cn(
+                  "h-4 w-4 border rounded flex items-center justify-center shrink-0",
+                  isSelected ? "bg-primary border-primary" : "border-input"
+                )}>
+                  {isSelected && <Check className="h-3 w-3 text-primary-foreground" />}
+                </div>
+                <span className="flex-1 truncate">{option.name}</span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {count} {count === 1 ? "post" : "posts"}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+        {selected.length > 0 && (
+          <div className="border-t p-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full"
+              onClick={() => onChange([])}
+            >
+              Clear all
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 function PostsContent() {
   const searchParams = useSearchParams()
+  const router = useRouter()
   const { contributor } = useContributor()
   const [posts, setPosts] = useState<Post[]>([])
   const [loading, setLoading] = useState(true)
@@ -34,7 +128,10 @@ function PostsContent() {
     sentiment: "",
     search: "",
     clustered: null as boolean | null, // true, false, or null (all)
+    productAreaIds: [] as number[],
   })
+  const [productAreas, setProductAreas] = useState<ProductArea[]>([])
+  const [postCountsByArea, setPostCountsByArea] = useState<Record<number, number>>({})
   const initialLoadDone = useRef(false)
   const searchTimeout = useRef<NodeJS.Timeout | null>(null)
 
@@ -42,7 +139,7 @@ function PostsContent() {
   const loadPosts = useCallback(async (currentFilters: typeof filters, currentContributorId?: number) => {
     setLoading(true)
     try {
-      const params: Record<string, string | number | boolean> = {}
+      const params: Record<string, string | number | boolean | number[]> = {}
 
       // Handle unified status filter
       if (currentFilters.status === "my_checkouts" && currentContributorId) {
@@ -54,14 +151,31 @@ function PostsContent() {
       if (currentFilters.sentiment) params.sentiment = currentFilters.sentiment
       if (currentFilters.search) params.search = currentFilters.search
       if (currentFilters.clustered !== null) params.clustered = currentFilters.clustered
+      if (currentFilters.productAreaIds.length > 0) params.product_area_ids = currentFilters.productAreaIds
 
-      const data = await getPosts(params)
+      const data = await getPosts(params as Parameters<typeof getPosts>[0])
       setPosts(data)
+
+      // Update post counts by area (from full dataset, not filtered)
+      const counts: Record<number, number> = {}
+      data.forEach((post) => {
+        if (post.product_area_id) {
+          counts[post.product_area_id] = (counts[post.product_area_id] || 0) + 1
+        }
+      })
+      if (currentFilters.productAreaIds.length === 0) {
+        setPostCountsByArea(counts)
+      }
     } catch (error) {
       console.error("Failed to load posts:", error)
     } finally {
       setLoading(false)
     }
+  }, [])
+
+  // Load product areas on mount
+  useEffect(() => {
+    getProductAreas().then(setProductAreas).catch(console.error)
   }, [])
 
   // Sync filters from URL params and load posts
@@ -79,7 +193,10 @@ function PostsContent() {
     // Parse clustered param
     const clusteredParam = searchParams.get("clustered")
     const clustered = clusteredParam === "true" ? true : clusteredParam === "false" ? false : null
-    const newFilters = { status, sentiment, search: filters.search, clustered }
+    // Parse product area ids
+    const paIdsParam = searchParams.get("product_area_ids")
+    const productAreaIds = paIdsParam ? paIdsParam.split(",").map(Number).filter(Boolean) : []
+    const newFilters = { status, sentiment, search: filters.search, clustered, productAreaIds }
     setFilters(newFilters)
     loadPosts(newFilters, contributor?.id)
     initialLoadDone.current = true
@@ -106,6 +223,28 @@ function PostsContent() {
     const newFilters = { ...filters, [key]: newValue }
     setFilters(newFilters)
     loadPosts(newFilters, contributor?.id)
+    updateUrl(newFilters)
+  }
+
+  // Handle product area filter changes
+  function handleProductAreaChange(ids: number[]) {
+    const newFilters = { ...filters, productAreaIds: ids }
+    setFilters(newFilters)
+    loadPosts(newFilters, contributor?.id)
+    updateUrl(newFilters)
+  }
+
+  // Update URL with current filters
+  function updateUrl(currentFilters: typeof filters) {
+    const params = new URLSearchParams()
+    if (currentFilters.status) params.set("status", currentFilters.status)
+    if (currentFilters.sentiment) params.set("sentiment", currentFilters.sentiment)
+    if (currentFilters.clustered !== null) params.set("clustered", String(currentFilters.clustered))
+    if (currentFilters.productAreaIds.length > 0) {
+      params.set("product_area_ids", currentFilters.productAreaIds.join(","))
+    }
+    const newUrl = params.toString() ? `/posts?${params.toString()}` : "/posts"
+    router.replace(newUrl, { scroll: false })
   }
 
   // Handle post update from PostCard (checkout/release)
@@ -173,6 +312,16 @@ function PostsContent() {
           </Select>
         </div>
 
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-muted-foreground">Product Area</span>
+          <ProductAreaFilter
+            options={productAreas}
+            selected={filters.productAreaIds}
+            onChange={handleProductAreaChange}
+            postCounts={postCountsByArea}
+          />
+        </div>
+
         <div className="space-y-1.5">
           <span className="text-xs text-muted-foreground">Search</span>
           <Input
@@ -183,19 +332,41 @@ function PostsContent() {
           />
         </div>
 
-        {(filters.status || filters.sentiment || filters.search || filters.clustered !== null) && (
+        {(filters.status || filters.sentiment || filters.search || filters.clustered !== null || filters.productAreaIds.length > 0) && (
           <Button
             variant="ghost"
             onClick={() => {
-              const cleared = { status: "", sentiment: "", search: "", clustered: null }
+              const cleared = { status: "", sentiment: "", search: "", clustered: null, productAreaIds: [] }
               setFilters(cleared)
               loadPosts(cleared, contributor?.id)
+              router.replace("/posts", { scroll: false })
             }}
           >
             Clear filters
           </Button>
         )}
       </div>
+
+      {/* Selected Filters Display */}
+      {filters.productAreaIds.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground">Showing posts in:</span>
+          {filters.productAreaIds.map((paId) => {
+            const pa = productAreas.find((p) => p.id === paId)
+            return pa ? (
+              <Badge key={paId} variant="secondary" className="flex items-center gap-1">
+                {pa.name}
+                <button
+                  onClick={() => handleProductAreaChange(filters.productAreaIds.filter(id => id !== paId))}
+                  className="ml-1 hover:text-destructive"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ) : null
+          })}
+        </div>
+      )}
 
       {/* Posts list */}
       {loading ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,6 +26,8 @@ export interface Post {
   resolved_at: string | null
   resolved_by: number | null
   resolved_by_name: string | null
+  product_area_id: number | null
+  product_area_name: string | null
 }
 
 export interface PostDetail extends Post {
@@ -144,11 +146,19 @@ export async function getPosts(params?: {
   resolved?: boolean
   status?: "waiting_for_pickup" | "in_progress" | "handled"
   clustered?: boolean
+  product_area_ids?: number[]
 }): Promise<Post[]> {
   const searchParams = new URLSearchParams()
   if (params) {
     Object.entries(params).forEach(([key, value]) => {
-      if (value !== undefined) searchParams.append(key, String(value))
+      if (value !== undefined) {
+        // Handle arrays (like product_area_ids) by appending each value
+        if (Array.isArray(value)) {
+          value.forEach((v) => searchParams.append(key, String(v)))
+        } else {
+          searchParams.append(key, String(value))
+        }
+      }
     })
   }
   const query = searchParams.toString()


### PR DESCRIPTION
## Summary
- Add product area filter to posts page with multi-select dropdown
- Add Mark Done / Reopen buttons directly on post cards (fixes #31)
- Clean up post card UI with horizontal badges and colored action buttons
- Make post body text clickable to drill down to detail

## Changes
- **Backend**: Add `product_area_id` and `product_area_name` to PostResponse, add `product_area_ids` filter param
- **Frontend**: Product area filter with URL sync, Mark Done/Reopen buttons, UI improvements

## Test plan
- [ ] Filter posts by product area
- [ ] Mark a post as done from the list
- [ ] Reopen a resolved post from the list
- [ ] Click post body to navigate to detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)