### PR TITLE
Require registered user for API access

### DIFF
--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -5,6 +5,7 @@ from app.auth.dependencies import (
     get_current_user_optional,
     require_contributor,
     require_contributor_write,
+    require_registered_user,
     require_service_principal,
     extract_alias_from_upn,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "get_current_user_optional",
     "require_contributor",
     "require_contributor_write",
+    "require_registered_user",
     "require_service_principal",
     "extract_alias_from_upn",
     "validate_token",

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -6,12 +6,12 @@ from datetime import datetime, timedelta
 from app.database import get_db
 from app.models import Post, Analysis, ContributorReply
 from app.schemas import OverviewStats, SentimentTrend
-from app.auth import get_current_user
+from app.auth import require_registered_user
 
 router = APIRouter(
     prefix="/api/analytics",
     tags=["analytics"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(require_registered_user)],
 )
 
 

--- a/backend/app/routers/clustering.py
+++ b/backend/app/routers/clustering.py
@@ -17,12 +17,12 @@ from app.schemas import (
     ThemeDetailResponse,
     ProductAreaTag,
 )
-from app.auth import get_current_user, require_contributor_write
+from app.auth import require_registered_user, require_contributor_write
 
 router = APIRouter(
     prefix="/api/clustering",
     tags=["clustering"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(require_registered_user)],
 )
 
 

--- a/backend/app/routers/contributors.py
+++ b/backend/app/routers/contributors.py
@@ -6,12 +6,12 @@ from datetime import datetime, timedelta
 from app.database import get_db
 from app.models import Contributor, ContributorReply, Post
 from app.schemas import ContributorCreate, ContributorResponse, ReaderCreate
-from app.auth import get_current_user, require_contributor_write
+from app.auth import require_registered_user, require_contributor_write
 
 router = APIRouter(
     prefix="/api/contributors",
     tags=["contributors"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(require_registered_user)],
 )
 
 

--- a/backend/app/routers/posts.py
+++ b/backend/app/routers/posts.py
@@ -17,12 +17,12 @@ from app.schemas import (
     ContributorReplyResponse,
 )
 from app.services.llm_analyzer import analyzer
-from app.auth import get_current_user, require_contributor_write
+from app.auth import require_registered_user, require_contributor_write
 
 router = APIRouter(
     prefix="/api/posts",
     tags=["posts"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(require_registered_user)],
 )
 
 

--- a/backend/app/routers/product_areas.py
+++ b/backend/app/routers/product_areas.py
@@ -9,12 +9,12 @@ from app.schemas import (
     ProductAreaUpdate,
     ProductAreaResponse,
 )
-from app.auth import get_current_user
+from app.auth import require_registered_user
 
 router = APIRouter(
     prefix="/api/product-areas",
     tags=["product-areas"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(require_registered_user)],
 )
 
 

--- a/backend/app/routers/scraper.py
+++ b/backend/app/routers/scraper.py
@@ -6,12 +6,12 @@ from app.database import get_db, SessionLocal
 from app.schemas import ScrapeRequest, ScrapeStatus
 from app.services.reddit_scraper import scraper
 from app.models import Post, Analysis
-from app.auth import get_current_user, require_contributor_write
+from app.auth import require_registered_user, require_contributor_write
 
 router = APIRouter(
     prefix="/api/scrape",
     tags=["scraper"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(require_registered_user)],
 )
 
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Providers } from "@/components/Providers"
 import { Sidebar } from "@/components/Sidebar"
 import { Header } from "@/components/Header"
 import { AuthGate } from "@/components/AuthGate"
+import { UnregisteredGate } from "@/components/UnregisteredGate"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -27,9 +28,11 @@ export default function RootLayout({
               <Sidebar />
               <div className="flex-1 flex flex-col">
                 <Header />
-                <main className="flex-1 overflow-auto">
-                  {children}
-                </main>
+                <UnregisteredGate>
+                  <main className="flex-1 overflow-auto">
+                    {children}
+                  </main>
+                </UnregisteredGate>
               </div>
             </div>
           </AuthGate>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -82,8 +82,8 @@ export function Header() {
         </Button>
       ) : null}
 
-      {/* Contributor selector - show if auth disabled OR authenticated but not linked to a contributor */}
-      {(!authEnabled || (isAuthenticated && !user?.contributorId)) && (
+      {/* Contributor selector - only show if auth is disabled (local dev mode) */}
+      {!authEnabled && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" className="flex items-center gap-2">

--- a/frontend/src/components/UnregisteredBanner.tsx
+++ b/frontend/src/components/UnregisteredBanner.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useAuth } from "@/lib/auth-context"
+import { AlertTriangle, Mail } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function UnregisteredBanner() {
+  const { user, authEnabled, logout } = useAuth()
+
+  // Only show if auth is enabled, user is authenticated, but not registered
+  if (!authEnabled || !user || user.contributorId !== null) {
+    return null
+  }
+
+  return (
+    <div className="flex-1 flex items-center justify-center p-8">
+      <div className="max-w-md text-center space-y-6">
+        <div className="mx-auto w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center">
+          <AlertTriangle className="h-8 w-8 text-amber-600" />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold">Access Required</h1>
+          <p className="text-muted-foreground">
+            You&apos;re signed in as <span className="font-medium">{user.email}</span>, but your account isn&apos;t registered for access to this tool.
+          </p>
+        </div>
+        <div className="bg-muted/50 rounded-lg p-4 text-sm text-left space-y-2">
+          <p className="font-medium">To get access:</p>
+          <p className="text-muted-foreground">
+            Contact an admin and ask them to add your Microsoft alias (<span className="font-mono">{user.alias}</span>) to the contributors list.
+          </p>
+        </div>
+        <Button variant="outline" onClick={logout}>
+          Sign out
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/UnregisteredGate.tsx
+++ b/frontend/src/components/UnregisteredGate.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useAuth } from "@/lib/auth-context"
+import { UnregisteredBanner } from "@/components/UnregisteredBanner"
+
+export function UnregisteredGate({ children }: { children: React.ReactNode }) {
+  const { user, authEnabled, isLoading } = useAuth()
+
+  // If auth is disabled or still loading, show children
+  if (!authEnabled || isLoading) {
+    return <>{children}</>
+  }
+
+  // If user is authenticated but not registered, show the banner
+  if (user && user.contributorId === null) {
+    return <UnregisteredBanner />
+  }
+
+  // User is registered, show children
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Unregistered users (authenticated via Azure AD but no matching alias in contributors table) are now blocked from all API endpoints
- Frontend shows an "Access Required" page with instructions to contact an admin

## Changes
- **Backend**: New `require_registered_user` dependency applied to all routers
- **Frontend**: `UnregisteredGate` component blocks content, shows friendly message with user's alias

## Test plan
- [ ] Sign in with unregistered account → see "Access Required" page
- [ ] API returns 403 for unregistered users
- [ ] Registered users have full access as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)