### PR TITLE
Prevent marking posts as done when checked out by another contributor

### DIFF
--- a/frontend/src/app/posts/detail/page.tsx
+++ b/frontend/src/app/posts/detail/page.tsx
@@ -372,7 +372,7 @@ function PostDetailContent() {
               </div>
             ) : (
               <>
-                {canPerformActions && contributor ? (
+                {canPerformActions && contributor && !isCheckedOutByOther ? (
                   <Button
                     variant="outline"
                     onClick={handleResolve}
@@ -383,7 +383,9 @@ function PostDetailContent() {
                   </Button>
                 ) : (
                   <span className="text-sm text-muted-foreground">
-                    {permissionReason || "Select a contributor to mark this post as done"}
+                    {isCheckedOutByOther
+                      ? `Cannot mark as done while ${post?.checked_out_by_name} is handling`
+                      : permissionReason || "Select a contributor to mark this post as done"}
                   </span>
                 )}
               </>

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -128,7 +128,7 @@ export function PostCard({ post, onPostUpdate }: PostCardProps) {
             {isCheckedOutByOther && (
               <Badge variant="outline" className="text-orange-600 border-orange-300">
                 <Lock className="h-3 w-3 mr-1" />
-                {post.checked_out_by_name}
+                {post.checked_out_by_name} is handling
               </Badge>
             )}
             {post.has_contributor_reply && (
@@ -188,7 +188,7 @@ export function PostCard({ post, onPostUpdate }: PostCardProps) {
                 Release
               </Button>
             )}
-            {contributor && !post.resolved && (
+            {contributor && !post.resolved && !isCheckedOutByOther && (
               <Button
                 size="sm"
                 variant="outline"


### PR DESCRIPTION
## Summary
- Add API validation to reject resolve requests when post is checked out by someone else (400 error)
- Hide "Mark Done" button in UI when post is checked out by another contributor
- Show explanation message on detail page: "Cannot mark as done while [Name] is handling"
- Marking as done releases the checkout

## Test plan
- [x] API returns 400 when trying to resolve post checked out by another
- [x] API allows owner to resolve (and releases checkout)
- [x] PostCard hides "Mark Done" when `isCheckedOutByOther`
- [x] Detail page shows explanation message when checked out by other

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)